### PR TITLE
Added ip address option handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var Server = function(inputStream, opts) {
   // stream playlist (points to other endpoint)
   var playlistEndpoint = function(req, res) {
 
-    var addr = ip.address();
+    var addr = opts.ipAddress || ip.address();
 
     res.status(200);
     res.set('Content-Type', 'audio/x-mpegurl');


### PR DESCRIPTION
I added the ability to pass in an ip address to bind to instead of relying on ip.address(). This was used to solve airsonos issue 27.