### PR TITLE
Correctly detect MetaData Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var Server = function(inputStream, opts) {
   // audio endpoint
   app.get('/listen', function(req, res, next) {
 
-    var acceptsMetadata = req.headers['icy-metadata'] === 1;
+    var acceptsMetadata = req.headers['icy-metadata'] == 1;
     var parsed = require('url').parse(req.url, true);
 
     // generate response header


### PR DESCRIPTION
With the current version, MetaData support is not detected in (for example) AirSonos
This is because the 'icy-metadata' header appears to be a String value of "1", rather than a numeric value of 1.
Reverting the comparison back to "==" instead of "===" relaxes the comparison, and allows AirSonos to send the song title etc. to the Sonos.
